### PR TITLE
WIP: Built-in clipboard manager

### DIFF
--- a/Fallback.py
+++ b/Fallback.py
@@ -1,0 +1,50 @@
+import sys
+import thread
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gdk
+
+
+# Simple clipboard manager which keep entries in memory as long as this manager is open
+name = 'Fallback'
+history = []
+gtkClipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+_thread = 0
+
+def canStart():
+    return True
+
+def isEnabled():
+    return True
+
+def isRunning():
+    return bool(_thread)
+
+def daemon(*args):
+    gtkClipboard.connect('owner-change', ownerChangeListener)
+    Gtk.main()
+
+def ownerChangeListener(*args):
+    text = gtkClipboard.wait_for_text()
+    print((text, history))
+
+    # Don't keep duplicates
+    if text in history:
+        history.remove(text)
+
+    history.append(text)
+
+def start():
+    global _thread
+    if not _thread:
+        try:
+            _thread = thread.start_new_thread(daemon, ())
+        except:
+           logger.error("Could not start Fallback manager")
+
+def stop():
+    print('@TODO: create me')
+
+def getHistory():
+    # Most recent should be first
+    return history[::-1]

--- a/main.py
+++ b/main.py
@@ -11,9 +11,10 @@ from lib import logger, pidOf, tryInt, ensureStatus, showStatus, entryAsResult, 
 import Clipster
 import CopyQ
 import GPaste
+import Fallback
 
 
-clipboardManagers = [CopyQ, GPaste, Clipster]
+clipboardManagers = [CopyQ, GPaste, Clipster, Fallback]
 sorter = lambda m: int("{}{}".format(int(m.isEnabled()), int(m.isRunning())))
 
 def getManager(name):

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
         "Auto",
         "Clipster",
         "CopyQ",
-        "GPaste"
+        "GPaste",
+        "Fallback"
       ]
     },
     {


### PR DESCRIPTION
Attempted built-in clipboard manager.

It stores entries you copy in an array, and lists them successfully, but when copying from within the extension (selecting an entry with enter or clicking) it breaks the copy action and itself (starts using a lot of resources). Not sure why. It's probably easy to fix.

Since clipster is used as the backup solution now, this isn't much needed anyway.

Update: This branch is stale and using unreliable GTK methods that I stopped using as of #15 and 9ac2695. Just keeping it around as a reminder. It won't be merged.