### PR TITLE
Add gtk main for some desktop environment to hold the clipboard content.

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -8,7 +8,7 @@ gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
 gi.require_version('Notify', '0.7')
 
-from gi.repository import Gdk, Gtk, Notify
+from gi.repository import Gdk, Gtk, Notify, GObject
 from time import sleep
 from distutils.spawn import find_executable as findExec
 
@@ -43,6 +43,8 @@ def setClipboard(text):
     clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
     clipboard.set_text(text, -1)
     clipboard.store()
+    GObject.timeout_add(1, Gtk.main_quit)
+    Gtk.main()
 
 def showMessage(title, message, icon, expires=Notify.EXPIRES_NEVER, urgency=2):
     message = Notify.Notification.new(title, message, icon)


### PR DESCRIPTION
I use Ubuntu 18.04 and have [this](https://stackoverflow.com/questions/15241203/effect-of-pygtk-clipboard-set-text-persists-only-while-process-is-running) issue. So every time I copy a clipboard content from ulauncher-clipboard, I can't paste it anywhere. It seems there's a problem with how X11 handle copying and pasting works.

Add `Gtk.main()` fix the issue for me.